### PR TITLE
url設定画面の実装

### DIFF
--- a/TitechAppLite.xcodeproj/project.pbxproj
+++ b/TitechAppLite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D1103CD4257CC7CA008F6ED1 /* urlSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */; };
 		D14B1319252852CD0006A30A /* LectureHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14B1318252852CD0006A30A /* LectureHeader.swift */; };
 		D14B132725285A270006A30A /* LectureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14B132625285A270006A30A /* LectureData.swift */; };
 		D1543657250364860073AC37 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1543656250364860073AC37 /* AppDelegate.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = urlSetting.swift; sourceTree = "<group>"; };
 		D14B1318252852CD0006A30A /* LectureHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LectureHeader.swift; path = TitechAppLite/View/LectureHeader.swift; sourceTree = SOURCE_ROOT; };
 		D14B132625285A270006A30A /* LectureData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureData.swift; sourceTree = "<group>"; };
 		D1543653250364860073AC37 /* TitechAppLite.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TitechAppLite.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -115,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				D154366A250367A90073AC37 /* LectureListView.swift */,
+				D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */,
 				D154366F25036C480073AC37 /* LectureRow.swift */,
 				D14B1318252852CD0006A30A /* LectureHeader.swift */,
 			);
@@ -220,6 +223,7 @@
 				D17940802528745200017467 /* LectureViewModel.swift in Sources */,
 				D1543659250364860073AC37 /* SceneDelegate.swift in Sources */,
 				D1D77ECF25723540005A4B53 /* APIClient.swift in Sources */,
+				D1103CD4257CC7CA008F6ED1 /* urlSetting.swift in Sources */,
 				D1D8ACF2253AC064003F4204 /* ICalResponseParser.swift in Sources */,
 				D1C130C32543FE73007D51DC /* ScheduleTranslator.swift in Sources */,
 				D14B132725285A270006A30A /* LectureData.swift in Sources */,
@@ -294,7 +298,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.7;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -349,7 +353,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.7;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/TitechAppLite.xcodeproj/project.pbxproj
+++ b/TitechAppLite.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D1103CD4257CC7CA008F6ED1 /* urlSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */; };
+		D1103CD4257CC7CA008F6ED1 /* UrlSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103CD3257CC7CA008F6ED1 /* UrlSetting.swift */; };
 		D14B1319252852CD0006A30A /* LectureHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14B1318252852CD0006A30A /* LectureHeader.swift */; };
 		D14B132725285A270006A30A /* LectureData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14B132625285A270006A30A /* LectureData.swift */; };
 		D1543657250364860073AC37 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1543656250364860073AC37 /* AppDelegate.swift */; };
@@ -24,7 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = urlSetting.swift; sourceTree = "<group>"; };
+		D1103CD3257CC7CA008F6ED1 /* UrlSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlSetting.swift; sourceTree = "<group>"; };
 		D14B1318252852CD0006A30A /* LectureHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LectureHeader.swift; path = TitechAppLite/View/LectureHeader.swift; sourceTree = SOURCE_ROOT; };
 		D14B132625285A270006A30A /* LectureData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureData.swift; sourceTree = "<group>"; };
 		D1543653250364860073AC37 /* TitechAppLite.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TitechAppLite.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -117,7 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				D154366A250367A90073AC37 /* LectureListView.swift */,
-				D1103CD3257CC7CA008F6ED1 /* urlSetting.swift */,
+				D1103CD3257CC7CA008F6ED1 /* UrlSetting.swift */,
 				D154366F25036C480073AC37 /* LectureRow.swift */,
 				D14B1318252852CD0006A30A /* LectureHeader.swift */,
 			);
@@ -223,7 +223,7 @@
 				D17940802528745200017467 /* LectureViewModel.swift in Sources */,
 				D1543659250364860073AC37 /* SceneDelegate.swift in Sources */,
 				D1D77ECF25723540005A4B53 /* APIClient.swift in Sources */,
-				D1103CD4257CC7CA008F6ED1 /* urlSetting.swift in Sources */,
+				D1103CD4257CC7CA008F6ED1 /* UrlSetting.swift in Sources */,
 				D1D8ACF2253AC064003F4204 /* ICalResponseParser.swift in Sources */,
 				D1C130C32543FE73007D51DC /* ScheduleTranslator.swift in Sources */,
 				D14B132725285A270006A30A /* LectureData.swift in Sources */,

--- a/TitechAppLite/AppDelegate.swift
+++ b/TitechAppLite/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        ScheduleTranslator.traslate(data: ICalResponseParser.parse(data: TestICalData.data(using: .utf8)!))
+//        ScheduleTranslator.traslate(data: ICalResponseParser.parse(data: TestICalData.data(using: .utf8)!))
         return true
     }
 

--- a/TitechAppLite/AppDelegate.swift
+++ b/TitechAppLite/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-//        ScheduleTranslator.traslate(data: ICalResponseParser.parse(data: TestICalData.data(using: .utf8)!))
         return true
     }
 

--- a/TitechAppLite/View/LectureListView.swift
+++ b/TitechAppLite/View/LectureListView.swift
@@ -30,9 +30,6 @@ struct LectureListView: View {
                 }, label: {
                     Text("設定")
                 })
-                // .sheet(isPresented: $showingModal) {
-//                urlSetting()
-//            }
             .sheet(isPresented: $showingModal,
                    onDismiss: { self.viewModel.appear() },
                    content: { urlSetting() }

--- a/TitechAppLite/View/LectureListView.swift
+++ b/TitechAppLite/View/LectureListView.swift
@@ -11,6 +11,7 @@ import Combine
 
 struct LectureListView: View {
     @ObservedObject var viewModel = LectureViewModel()
+    @State private var showingModal = false
     
     var body: some View {
         NavigationView {
@@ -22,6 +23,21 @@ struct LectureListView: View {
                         }
                     }
                 }.listRowInsets(EdgeInsets())
+            }
+            .toolbar {
+                Button(action: {
+                    self.showingModal.toggle()
+                }, label: {
+                    Text("設定")
+                })
+                // .sheet(isPresented: $showingModal) {
+//                urlSetting()
+//            }
+            .sheet(isPresented: $showingModal,
+                   onDismiss: { self.viewModel.appear() },
+                   content: { urlSetting() }
+            )
+                
             }
             .navigationBarTitle("スケジュール")
         }

--- a/TitechAppLite/View/UrlSetting.swift
+++ b/TitechAppLite/View/UrlSetting.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct urlSetting: View {
+struct UrlSetting: View {
     @State private var url = ""
     @State private var isShown = true
     @Environment(\.presentationMode) var presentationMode

--- a/TitechAppLite/View/urlSetting.swift
+++ b/TitechAppLite/View/urlSetting.swift
@@ -1,0 +1,43 @@
+//
+//  urlSetting.swift
+//  TitechAppLite
+//
+//  Created by 高嶋優希 on 2020/12/06.
+//  Copyright © 2020 takachy. All rights reserved.
+//
+
+import SwiftUI
+
+struct urlSetting: View {
+    @State private var url = ""
+    @State private var isShown = true
+    @Environment(\.presentationMode) var presentationMode
+    
+    var body: some View {
+        VStack {
+            TextField("https://", text: $url)
+                .textFieldStyle(RoundedBorderTextFieldStyle())  // 入力域のまわりを枠で囲む
+                .padding()  // 余白を追加
+                .autocapitalization(UITextAutocapitalizationType.none)
+                .keyboardType(.URL)
+            Button(action: {
+                guard let saveUrl = URL(string: url)
+                    else{
+                        print("Error")
+                        return
+                    }
+                UserDefaults.standard.set(saveUrl, forKey: "OCWi_url")
+                self.presentationMode.wrappedValue.dismiss()
+                }
+            ) {
+                Text("保存")
+            }
+        }
+    }
+}
+
+struct urlSetting_Previews: PreviewProvider {
+    static var previews: some View {
+        urlSetting()
+    }
+}

--- a/TitechAppLite/ViewModel/LectureViewModel.swift
+++ b/TitechAppLite/ViewModel/LectureViewModel.swift
@@ -16,7 +16,8 @@ class LectureViewModel: ObservableObject {
     
     func appear() {
         cancellable = APIClient().fetch(
-            url: URL(string: "https://ocwi-mock.titech.app/ocwi/index.php?module=Ocwi&action=Webcal&iCalendarId=test")!
+            url: UserDefaults.standard.url(forKey: "OCWi_url")
+                ?? URL(string: "https://ocwi-mock.titech.app/ocwi/index.php?module=Ocwi&action=Webcal&iCalendarId=test")!
         )
         .map {data in
             ScheduleTranslator.traslate(data: ICalResponseParser.parse(data: data))


### PR DESCRIPTION
### 概要
OCW-iのiCalデータをurlから更新できるようにスケジュール上部にボタンを設定した

### SS
|  スケジュール |  設定画面|
| ---- | ---- |
| ![Simulator Screen Shot - iPod touch (7th generation) - 2021-01-16 at 15 36 03](https://user-images.githubusercontent.com/49744299/104799230-c8695780-5810-11eb-9f5a-b67250bf295a.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2021-01-16 at 15 36 11](https://user-images.githubusercontent.com/49744299/104799236-d28b5600-5810-11eb-9cd7-2b9c4a2885ee.png)|